### PR TITLE
Fix audit log and firestore util

### DIFF
--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -1,17 +1,23 @@
-import firebase from 'firebase/app';
-import 'firebase/firestore';
-import { db } from './firebaseConfig'; // Assuming you have initialized Firestore in firebaseConfig.ts
+import {
+  collection,
+  addDoc,
+  Timestamp,
+  DocumentReference,
+} from 'firebase/firestore';
+import { firestore as db } from './firebaseConfig';
 
 export interface TherapySessionNote {
   therapistId: string;
-  createdAt: firebase.firestore.Timestamp;
+  createdAt: Timestamp;
   structuredContent: string;
-  sessionDate: firebase.firestore.Timestamp;
+  sessionDate: Timestamp;
 }
 
-export async function saveTherapySessionNote(note: TherapySessionNote): Promise<firebase.firestore.DocumentReference> {
+export async function saveTherapySessionNote(
+  note: TherapySessionNote
+): Promise<DocumentReference> {
   try {
-    const docRef = await db.collection('therapySessionNotes').add(note);
+    const docRef = await addDoc(collection(db, 'therapySessionNotes'), note);
     return docRef;
   } catch (error) {
     console.error('Error saving therapy session note:', error);


### PR DESCRIPTION
## Summary
- log audit events inside `generateNote` handler
- update Firestore helper to use modular API

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f403d86888328a86788e7c8ef683d