### PR TITLE
Add @types/cors to functions

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -10,6 +10,7 @@
         "firebase-functions": "^6.3.2"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.17",
         "@types/node": "^20.12.12",
         "@types/node-fetch": "^2.6.12",
         "eslint": "^8.57.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@types/node": "^20.12.12",
     "@types/node-fetch": "^2.6.12",
+    "@types/cors": "^2.8.17",
     "eslint": "^8.57.0",
     "eslint-plugin-import": "^2.29.1",
     "typescript": "^5.8.3"


### PR DESCRIPTION
## Summary
- add `@types/cors` as a dev dependency for Firebase functions
- regenerate `package-lock.json`

## Testing
- `npm install` within `functions`
- `npm run build` *(fails: Cannot find module 'microsoft-cognitiveservices-speech-sdk' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684495bda32c83289cad43a7350808b8